### PR TITLE
Fix code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/apps/image-search-abstraction-layer/public/imageSearch.js
+++ b/apps/image-search-abstraction-layer/public/imageSearch.js
@@ -37,16 +37,16 @@ function updateURL() {
   var queryTest = /\S/;
 
   if (selected == 'query' && queryTest.test(queryValue)) {
-    url += 'query/' + queryValue + '?page=' + pageValue;
+    url += 'query/' + encodeURIComponent(queryValue) + '?page=' + encodeURIComponent(pageValue);
     if (sizeValue != 'All') {
-      url += '&size=' + sizeValue;
+      url += '&size=' + encodeURIComponent(sizeValue);
     }
   }
   if (selected == 'recent') {
     url += 'recent/';
   }
 
-  urlDiv.innerHTML = url;
+  urlDiv.textContent = url;
   urlDiv.setAttribute('href', url);
 }
 


### PR DESCRIPTION
Fixes [https://github.com/devanshbatham/demo-projects/security/code-scanning/9](https://github.com/devanshbatham/demo-projects/security/code-scanning/9)

To fix this issue, we need to ensure that any user input is properly sanitized or escaped before being used in a context where it can be interpreted as HTML. In this case, we should use `textContent` instead of `innerHTML` to avoid interpreting the text as HTML. Additionally, we should ensure that the URL is properly encoded.

- Replace `urlDiv.innerHTML = url;` with `urlDiv.textContent = url;` to prevent the text from being interpreted as HTML.
- Ensure that the URL is properly encoded using `encodeURIComponent` for the query parameters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
